### PR TITLE
Allow to be installed with node >=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"typescript": "^4.9.0"
 	},
 	"engines": {
-		"node": "^18"
+		"node": ">=18"
 	},
 	"peerDependencies": {
 		"react": "17.0.2",


### PR DESCRIPTION
When running yarn on Node higher than 18 it fails with:

> error matomo-react@1.0.7: The engine "node" is incompatible with this module. Expected version "^18". Got "20.10.0"